### PR TITLE
Correctly list servers already running at startup. Fix #29.

### DIFF
--- a/src/ofxSyphonServerDirectory.mm
+++ b/src/ofxSyphonServerDirectory.mm
@@ -42,6 +42,7 @@ void ofxSyphonServerDirectory::setup ()
     {
 		bSetup = true;
         addObservers();
+        refresh(true);
 	}
 }
 


### PR DESCRIPTION
As requested :-)