### PR TITLE
add bind function to avoid texture copy

### DIFF
--- a/src/ofxSyphonServer.h
+++ b/src/ofxSyphonServer.h
@@ -10,14 +10,19 @@
 #include "ofMain.h"
 
 class ofxSyphonServer {
-	public:
+public:
 	ofxSyphonServer();
 	~ofxSyphonServer();
 	void setName (string n);
 	string getName();
 	void publishScreen();
-    void publishTexture(ofTexture* inputTexture);
-    void publishTexture(GLuint id, GLenum target, GLsizei width, GLsizei height, bool isFlipped);
-	protected:
+	void publishTexture(ofTexture* inputTexture);
+	void publishTexture(GLuint id, GLenum target, GLsizei width, GLsizei height, bool isFlipped);
+	bool tryToBindForSize(int w,int h);
+	void unbindAndPublish();
+	ofTexture & getCurrentTexture();
+	void updateCurrentTexture();
+protected:
+	ofTexture mTex;
 	void *mSyphon;
 };

--- a/src/ofxSyphonServer.mm
+++ b/src/ofxSyphonServer.mm
@@ -115,3 +115,68 @@ void ofxSyphonServer::publishTexture(GLuint id, GLenum target, GLsizei width, GL
     [pool drain];
     
 }
+
+bool ofxSyphonServer::tryToBindForSize(int w,int h){
+  bool res;
+  @autoreleasepool{
+
+    if (!mSyphon)
+    {
+      mSyphon = [[SyphonServer alloc] initWithName:@"Untitled" context:CGLGetCurrentContext() options:nil];
+    }
+
+    res = [(SyphonServer *)mSyphon bindToDrawFrameOfSize:NSMakeSize( w,h)];
+    if(res){
+      ofViewport(0,0,w,h,false);
+      ofSetupScreenOrtho(w,h);
+      ofPushMatrix();
+      ofPushView();
+    }
+  }
+  
+		return res;
+}
+
+void ofxSyphonServer::unbindAndPublish(){
+  if (mSyphon){
+    @autoreleasepool{
+      [(SyphonServer *)mSyphon unbindAndPublish];
+
+      updateCurrentTexture();
+      ofPopView();
+      ofPopMatrix();
+    }
+  }
+}
+
+ofTexture & ofxSyphonServer::getCurrentTexture(){
+  return mTex;
+}
+void ofxSyphonServer::updateCurrentTexture(){
+
+  if(!mSyphon) return ;
+  @autoreleasepool{
+    SyphonImage * Img =[(SyphonServer *)mSyphon newFrameImage] ;
+    NSSize texSize = [(SyphonImage*)Img textureSize];
+    mTex.setUseExternalTextureID([Img textureName]);
+
+
+    mTex.texData.textureTarget = GL_TEXTURE_RECTANGLE_ARB;  // Syphon always outputs rect textures.
+    mTex.texData.width = texSize.width;
+    mTex.texData.height = texSize.height;
+    mTex.texData.tex_w = texSize.width;
+    mTex.texData.tex_h = texSize.height;
+    mTex.texData.tex_t = texSize.width;
+    mTex.texData.tex_u = texSize.height;
+    mTex.texData.glInternalFormat = GL_RGBA;
+#if (OF_VERSION_MAJOR == 0) && (OF_VERSION_MINOR < 8)
+    mTex.texData.glType = GL_RGBA;
+    mTex.texData.pixelType = GL_UNSIGNED_BYTE;
+#endif
+    mTex.texData.bFlipTexture = YES;
+    mTex.texData.bAllocated = YES;
+    
+    
+  }
+  
+}


### PR DESCRIPTION
Hi guys,
I've recently discovered that syphon copy texture if used via publish texture,
I've seen in openGL profiler (and in the code comments) that a second texture was used for syphon servers.

So I've tried to add a true bind functionality using syphon's bindToDrawFrameOfSize to avoid texture copy.
few comments :
- I'm not an objective-C coder, so the few bits I've added there can be wrongly implemented
- I presume that having one texture instead of two is best but I'm not completly aware of syphon mechanisms

if the above sounds right i think it can be seen as a possibility to reduce graphics memory by two for ofxSyphon projects isn't it?

let me know what you think
