### PR TITLE
update to std:string usage

### DIFF
--- a/src/ofxSyphonClient.h
+++ b/src/ofxSyphonClient.h
@@ -21,13 +21,13 @@ class ofxSyphonClient {
     bool isSetup();
     
     void set(ofxSyphonServerDescription _server);
-    void set(string _serverName, string _appName);
+    void set(std::string _serverName, std::string _appName);
     
-    void setApplicationName(string _appName);
-    void setServerName(string _serverName);
+    void setApplicationName(std::string _appName);
+    void setServerName(std::string _serverName);
     
-    string& getApplicationName();
-    string& getServerName();
+    std::string& getApplicationName();
+    std::string& getServerName();
   
     void bind();
     void unbind();
@@ -54,5 +54,5 @@ class ofxSyphonClient {
 	ofTexture mTex;
 	int width, height;
 	bool bSetup;
-    string appName, serverName;
+    std::string appName, serverName;
 };

--- a/src/ofxSyphonClient.mm
+++ b/src/ofxSyphonClient.mm
@@ -82,7 +82,7 @@ void ofxSyphonClient::set(ofxSyphonServerDescription _server){
     set(_server.serverName, _server.appName);
 }
 
-void ofxSyphonClient::set(string _serverName, string _appName){
+void ofxSyphonClient::set(std::string _serverName, std::string _appName){
     if(bSetup)
     {
         NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
@@ -100,7 +100,7 @@ void ofxSyphonClient::set(string _serverName, string _appName){
     }
 }
 
-void ofxSyphonClient::setApplicationName(string _appName)
+void ofxSyphonClient::setApplicationName(std::string _appName)
 {
     if(bSetup)
     {
@@ -116,7 +116,7 @@ void ofxSyphonClient::setApplicationName(string _appName)
     }
     
 }
-void ofxSyphonClient::setServerName(string _serverName)
+void ofxSyphonClient::setServerName(std::string _serverName)
 {
     if(bSetup)
     {
@@ -135,11 +135,11 @@ void ofxSyphonClient::setServerName(string _serverName)
     }    
 }
 
-string& ofxSyphonClient::getApplicationName(){
+std::string& ofxSyphonClient::getApplicationName(){
     return appName;
 }
 
-string& ofxSyphonClient::getServerName(){
+std::string& ofxSyphonClient::getServerName(){
     return serverName;
 }
 

--- a/src/ofxSyphonServer.h
+++ b/src/ofxSyphonServer.h
@@ -13,8 +13,8 @@ class ofxSyphonServer {
 	public:
 	ofxSyphonServer();
 	~ofxSyphonServer();
-	void setName (string n);
-	string getName();
+	void setName (std::string n);
+	std::string getName();
 	void publishScreen();
     void publishTexture(ofTexture* inputTexture);
     void publishTexture(GLuint id, GLenum target, GLsizei width, GLsizei height, bool isFlipped);

--- a/src/ofxSyphonServer.mm
+++ b/src/ofxSyphonServer.mm
@@ -26,7 +26,7 @@ ofxSyphonServer::~ofxSyphonServer()
 }
 
 
-void ofxSyphonServer::setName(string n)
+void ofxSyphonServer::setName(std::string n)
 {
     NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
     
@@ -45,9 +45,9 @@ void ofxSyphonServer::setName(string n)
     [pool drain];
 }
 
-string ofxSyphonServer::getName()
+std::string ofxSyphonServer::getName()
 {
-	string name;
+	std::string name;
 	if (mSyphon)
 	{
 		NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];

--- a/src/ofxSyphonServerDirectory.h
+++ b/src/ofxSyphonServerDirectory.h
@@ -19,7 +19,7 @@ public:
         serverName = appName = "null";
     }
     
-	ofxSyphonServerDescription(string _serverName, string _appName)
+	ofxSyphonServerDescription(std::string _serverName, std::string _appName)
 	{
         serverName = _serverName;
         appName = _appName;
@@ -30,7 +30,7 @@ public:
         return (lhs.serverName == rhs.serverName) && (lhs.appName == rhs.appName);
     }
     
-	string serverName, appName;
+	std::string serverName, appName;
 };
 
 class ofxSyphonServerDirectoryEventArgs : public ofEventArgs {
@@ -55,7 +55,7 @@ public:
     int size();
 
     bool isValidIndex(int _idx);
-    bool serverExists(string _serverName, string _appName);
+    bool serverExists(std::string _serverName, std::string _appName);
     bool serverExists(ofxSyphonServerDescription _server);
     ofxSyphonServerDescription& getDescription(int _idx);
     
@@ -80,4 +80,3 @@ private:
 	bool bSetup;
     vector<ofxSyphonServerDescription> serverList;
 };
-

--- a/src/ofxSyphonServerDirectory.mm
+++ b/src/ofxSyphonServerDirectory.mm
@@ -106,7 +106,7 @@ bool ofxSyphonServerDirectory::serverExists(ofxSyphonServerDescription _server){
     return false;
 }
 
-bool ofxSyphonServerDirectory::serverExists(string _serverName, string _appName){
+bool ofxSyphonServerDirectory::serverExists(std::string _serverName, std::string _appName){
     return serverExists(ofxSyphonServerDescription(_serverName, _appName));
 }
 


### PR DESCRIPTION
The OF API has transitioned to explicitly using the `std` namespace when declaring types and this PR updates the ofxSyphon API to use `std::string` instead of `string`. This should have no effect on existing projects.

Also, I'm building ofxSyphon as a Lua module for an [OF + Lua interpreter](https://github.com/danomatika/loaf) and the bindings generation works with std::string, so this help me out. :)