### PR TITLE
include CoreFondation.h

### DIFF
--- a/src/ofxSyphonServer.h
+++ b/src/ofxSyphonServer.h
@@ -9,6 +9,7 @@
 
 #include "ofMain.h"
 #include "ofxSyphonNSObject.hpp"
+#include <CoreFoundation/CoreFoundation.h>
 
 class ofxSyphonServer {
 	public:


### PR DESCRIPTION
On MacOS 15 compiling ofxSyphon fail and complain about undefined types (CFStringRef, CFDictionaryRef)

adding this include compile gracefully
